### PR TITLE
Update Durable Task SDK version

### DIFF
--- a/examples/Workflow/WorkflowWebApp/Program.cs
+++ b/examples/Workflow/WorkflowWebApp/Program.cs
@@ -1,61 +1,51 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Routing;
-using System.Web;
-using Microsoft.AspNetCore.Http;
-using Dapr.Workflow;
+﻿using Dapr.Workflow;
 
 // The workflow host is a background service that connects to the sidecar over gRPC
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
+// Dapr workflows are registered as part of the service configuration
 builder.Services.AddWorkflow(options =>
 {
+    // Example of registering a "Hello World" workflow function
     options.RegisterWorkflow<string, string>("HelloWorld", implementation: async (context, input) => 
     {
         string result  = "";
         result = await context.CallActivityAsync<string>("SayHello", "World");
         return result;
     });
-    options.RegisterActivity<string, string>("SayHello", implementation: async (context, input) => await Task.FromResult($"Hello, {input}!"));
+
+    // Example of registering a "Say Hello" workflow activity function
+    options.RegisterActivity<string, string>("SayHello", implementation: (context, input) =>
+    {
+        return Task.FromResult($"Hello, {input}!");
+    });
 });
 
 WebApplication app = builder.Build();
 
-app.UseRouting();
-
-app.UseEndpoints(endpoints =>
+// POST starts new workflow instances
+app.MapPost("/workflow", async (HttpContext context, WorkflowClient client) =>
 {
-    endpoints.MapPost("/workflow", Schedule);
-
-    endpoints.MapGet("/workflow/{id}", GetWorkflow);
-});
-
-async Task<IResult> Schedule(HttpContext context)
-{
-    var client = context.RequestServices.GetRequiredService<WorkflowClient>();
     string id = Guid.NewGuid().ToString()[..8];
     await client.ScheduleNewWorkflowAsync("HelloWorld", id);
-    return Results.Ok(id);
-}
 
-async Task<IResult> GetWorkflow(HttpContext context)
+    // return an HTTP 202 and a Location header to be used for status query
+    return Results.AcceptedAtRoute("GetWorkflowEndpoint", new { id });
+});
+
+// GET fetches metadata for specific workflow instances
+app.MapGet("/workflow/{id}", async (string id, WorkflowClient client) =>
 {
-    var id = (string)context.Request.RouteValues["id"];
-    var client = context.RequestServices.GetRequiredService<WorkflowClient>();
     WorkflowMetadata metadata = await client.GetWorkflowMetadataAsync(id, getInputsAndOutputs: true);
     if (metadata.Exists)
     {
-        Console.WriteLine($"Created workflow id: '{id}'");
-        Console.WriteLine($"Metadata:  {metadata.Details}");
         return Results.Ok(metadata);
     }
     else
     {
         return Results.NotFound($"No workflow with ID = '{id}' was found.");
     }
-}
+}).WithName("GetWorkflowEndpoint");
 
 app.Run("http://0.0.0.0:8080");
+

--- a/examples/Workflow/WorkflowWebApp/WorkflowWebApp.csproj
+++ b/examples/Workflow/WorkflowWebApp/WorkflowWebApp.csproj
@@ -7,6 +7,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
 

--- a/src/Dapr.Workflow/Dapr.Workflow.csproj
+++ b/src/Dapr.Workflow/Dapr.Workflow.csproj
@@ -12,7 +12,8 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.DurableTask.Client" Version="0.4.1-beta" />
+    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="1.0.0-rc.1" />
+    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="1.0.0-rc.1" />
     <PackageReference Include="Dapr.AspNetCore" Version="1.8.0" />
   </ItemGroup>
 

--- a/src/Dapr.Workflow/WorkflowClient.cs
+++ b/src/Dapr.Workflow/WorkflowClient.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2022 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,13 +12,13 @@
 // ------------------------------------------------------------------------
 
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DurableTask;
-using Microsoft.DurableTask.Grpc;
+using Microsoft.DurableTask.Client;
 
 namespace Dapr.Workflow
 {
+    // TODO: This will be replaced by the official Dapr Workflow management client.
     /// <summary>
     /// Defines client operations for managing Dapr Workflow instances.
     /// </summary>
@@ -26,15 +26,14 @@ namespace Dapr.Workflow
     {
         readonly DurableTaskClient innerClient;
 
-        internal WorkflowClient(IServiceProvider? services = null)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WorkflowClient"/> class.
+        /// </summary>
+        /// <param name="innerClient">The Durable Task client used to communicate with the Dapr sidecar.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="innerClient"/> is <c>null</c>.</exception>
+        public WorkflowClient(DurableTaskClient innerClient)
         {
-            DurableTaskGrpcClient.Builder builder = new();
-            if (services != null)
-            {
-                builder.UseServices(services);
-            }
-
-            this.innerClient = builder.Build();
+            this.innerClient = innerClient ?? throw new ArgumentNullException(nameof(innerClient));
         }
 
         /// <summary>
@@ -46,7 +45,8 @@ namespace Dapr.Workflow
             object? input = null,
             DateTime? startTime = null)
         {
-            return this.innerClient.ScheduleNewOrchestrationInstanceAsync(name, instanceId, input, startTime);
+            StartOrchestrationOptions options = new(instanceId, startTime);
+            return this.innerClient.ScheduleNewOrchestrationInstanceAsync(name, input, options);
         }
 
         /// <summary>
@@ -69,5 +69,3 @@ namespace Dapr.Workflow
         }
     }
 }
-
-

--- a/src/Dapr.Workflow/WorkflowMetadata.cs
+++ b/src/Dapr.Workflow/WorkflowMetadata.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2022 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 // limitations under the License.
 // ------------------------------------------------------------------------
 
-using Microsoft.DurableTask;
+using Microsoft.DurableTask.Client;
 
 namespace Dapr.Workflow
 {


### PR DESCRIPTION
Updating your existing PR with one that:

* Updates the Durable Task SDK dependency from 0.4.1-beta to 1.0.0-rc.1
* Simplifies the example ASP.NET Core web app (just removes some unnecessary ceremony)

Let me know if you have any questions about these changes!